### PR TITLE
feat: extend dataframe benchmarks with pyarrow-backed pandas input

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ For e2e test suite ([benchmark-e2e-overlap](conf/paper/benchmark-e2e-overlap.yam
 export POLARS_MAX_THREADS=1
 ```
 
+For `input_dataframes: true` benchmarks, `dataframes_io` also supports
+`pandas.pyarrow.DataFrame`. That reads parquet through pandas with
+`engine="pyarrow"` and `dtype_backend="pyarrow"` so the loaded columns stay
+Arrow-backed:
+
+```yaml
+dataframes_io:
+  - "pandas.DataFrame:pandas.DataFrame"
+  - "pandas.pyarrow.DataFrame:pandas.DataFrame"
+```
+
 
 ### Datasets
 [Datasets overview](https://biodatageeks.org/polars-bio/performance/#test-datasets)
@@ -238,4 +249,3 @@ To fix this, you can set the following environment variable when installing or u
 ```shell
  RUSTFLAGS="-Clink-arg=-undefined -Clink-arg=dynamic_lookup -Ctarget-cpu=native" poetry update
 ```
-

--- a/conf/benchmark_dataframes.yaml
+++ b/conf/benchmark_dataframes.yaml
@@ -12,6 +12,7 @@ benchmarks:
     dataframes_io:
       - "polars.DataFrame:polars.DataFrame"
       - "pandas.DataFrame:pandas.DataFrame"
+      - "pandas.pyarrow.DataFrame:pandas.DataFrame"
       - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
@@ -32,6 +33,7 @@ benchmarks:
     dataframes_io:
       - "polars.DataFrame:polars.DataFrame"
       - "pandas.DataFrame:pandas.DataFrame"
+      - "pandas.pyarrow.DataFrame:pandas.DataFrame"
       - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1

--- a/conf/benchmark_dataframes.yaml
+++ b/conf/benchmark_dataframes.yaml
@@ -6,12 +6,13 @@ benchmarks:
     dataset: databio
     tools:
       - polars_bio
-      - pyranges0
+      - pyranges1
     parallel: false
     input_dataframes: true
     dataframes_io:
       - "polars.DataFrame:polars.DataFrame"
       - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -25,12 +26,13 @@ benchmarks:
     dataset: databio
     tools:
       - polars_bio
-      - pyranges0
+      - pyranges1
     parallel: false
     input_dataframes: true
     dataframes_io:
       - "polars.DataFrame:polars.DataFrame"
       - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:

--- a/conf/blog/benchmark_single_thread-2tools-dataframes-benchmark-2026.yaml
+++ b/conf/blog/benchmark_single_thread-2tools-dataframes-benchmark-2026.yaml
@@ -4,16 +4,18 @@ common:
   polars_bio_coordinate_system: 0-based
   polars_bio_consume_mode: len
 benchmarks:
-  - name: overlap-single-3tools
+  - name: overlap-single-2tools-dataframes
     operation: overlap
     dataset: databio
     tools:
       - polars_bio
       - pyranges1
-#      - genomicranges
-      - bioframe
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -24,16 +26,18 @@ benchmarks:
       - "7-8"
       - "8-7"
 
-  - name: nearest-single-3tools
+  - name: nearest-single-2tools-dataframes
     operation: nearest
     dataset: databio
     tools:
       - polars_bio
       - pyranges1
-#      - genomicranges
-      - bioframe
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -44,16 +48,18 @@ benchmarks:
       - "7-8"
       - "8-7"
 
-  - name: count_overlaps-single-3tools
+  - name: count_overlaps-single-2tools-dataframes
     operation: count_overlaps
     dataset: databio
     tools:
       - polars_bio
       - pyranges1
-#      - genomicranges
-      - bioframe
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -63,15 +69,19 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
-  - name: coverage-single-2tools
+
+  - name: coverage-single-2tools-dataframes
     operation: coverage
     dataset: databio
     tools:
       - polars_bio
-#      - genomicranges
-      - bioframe
+      - pyranges1
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -81,16 +91,19 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
-  - name: merge-single-3tools
+
+  - name: merge-single-2tools-dataframes
     operation: merge
     dataset: databio
     tools:
       - polars_bio
-      - bioframe
       - pyranges1
-#      - genomicranges
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -102,15 +115,18 @@ benchmarks:
       - "7-8"
       - "8-7"
 
-  - name: cluster-single-3tools
+  - name: cluster-single-2tools-dataframes
     operation: cluster
     dataset: databio
     tools:
       - polars_bio
-      - bioframe
       - pyranges1
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -122,16 +138,18 @@ benchmarks:
       - "7-8"
       - "8-7"
 
-  - name: complement-single-3tools
+  - name: complement-single-2tools-dataframes
     operation: complement
     dataset: databio
     tools:
       - polars_bio
-      - bioframe
       - pyranges1
-#      - genomicranges
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:
@@ -142,16 +160,19 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
-  - name: subtract-single-3tools
+
+  - name: subtract-single-2tools-dataframes
     operation: subtract
     dataset: databio
     tools:
       - polars_bio
-      - bioframe
       - pyranges1
-#      - genomicranges
     parallel: false
-    input_dataframes: false
+    input_dataframes: true
+    dataframes_io:
+      - "pandas.DataFrame:pandas.DataFrame"
+      - "polars.DataFrame:polars.DataFrame"
+      - "polars.LazyFrame:polars.LazyFrame"
     num_repeats: 3
     num_executions: 1
     test-cases:

--- a/conf/blog/benchmark_single_thread-4tools-benchmark-2026-count.yaml
+++ b/conf/blog/benchmark_single_thread-4tools-benchmark-2026-count.yaml
@@ -2,7 +2,7 @@ common:
   baseline: polars_bio
   polars_bio_output_type: polars.LazyFrame
   polars_bio_coordinate_system: 0-based
-  polars_bio_consume_mode: len
+  polars_bio_consume_mode: count
 benchmarks:
   - name: overlap-single-3tools
     operation: overlap
@@ -63,6 +63,7 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
+
   - name: coverage-single-2tools
     operation: coverage
     dataset: databio
@@ -81,6 +82,7 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
+
   - name: merge-single-3tools
     operation: merge
     dataset: databio
@@ -142,6 +144,7 @@ benchmarks:
       - "7-3"
       - "7-8"
       - "8-7"
+
   - name: subtract-single-3tools
     operation: subtract
     dataset: databio

--- a/src/operations.py
+++ b/src/operations.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Any
 
 import bioframe as bf
 import pandas as pd
@@ -10,131 +11,236 @@ from memory_profiler import profile
 from utils import df2pr1, overlaps_to_df
 
 columns = ("contig", "pos_start", "pos_end")
+OUTPUT_CSV = "/tmp/output.csv"
+POLARS_BIO_CONSUME_MODES = {"count", "len"}
 
 
-def _collect_lazyframe_count(df: pl.LazyFrame):
-    df.count().collect()
+def _pandas_parquet_path(path: str | None) -> str | None:
+    if path is None:
+        return None
+    return path.replace("*.parquet", "")
 
 
-def nearest_bioframe(df_1, df_2):
-    len(bf.closest(df_1, df_2, cols1=columns, cols2=columns))
+def _read_pandas_parquet(path: str | None) -> pd.DataFrame | None:
+    parquet_path = _pandas_parquet_path(path)
+    if parquet_path is None:
+        return None
+    return pd.read_parquet(parquet_path, engine="pyarrow")
 
 
-def nearest_polars_bio(df_path_1, df_path_2, output_type):
+def _collect_lazyframe_count(df: pl.LazyFrame) -> int:
+    return int(df.select(pl.len()).collect().item())
+
+
+def _normalize_polars_bio_consume_mode(consume_mode: str) -> str:
+    normalized_consume_mode = consume_mode.strip().lower()
+    if normalized_consume_mode not in POLARS_BIO_CONSUME_MODES:
+        raise ValueError(f"Unsupported polars_bio consume mode: {consume_mode}")
+    return normalized_consume_mode
+
+
+def _collect_datafusion_len(df: Any) -> int:
+    return sum(batch.num_rows for batch in df.collect())
+
+
+def _consume_polars_bio_result(
+    df: Any,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    normalized_consume_mode = _normalize_polars_bio_consume_mode(consume_mode)
     if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.nearest(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
-    else:
-        len(
-            pb.nearest(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
+        if normalized_consume_mode == "count":
+            return _collect_lazyframe_count(df)
+        return len(df.collect())
+    if output_type == "datafusion.DataFrame":
+        if normalized_consume_mode == "count":
+            return int(df.count())
+        return _collect_datafusion_len(df)
+    return len(df)
 
 
-def nearest_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.nearest_ranges(df_2_pr1))
+def _write_csv(df: Any) -> None:
+    if isinstance(df, pl.DataFrame):
+        df.write_csv(OUTPUT_CSV)
+        return
+    if hasattr(df, "to_polars"):
+        df.to_polars().write_csv(OUTPUT_CSV)
+        return
+    df.to_csv(OUTPUT_CSV)
 
 
-def nearest_pybedtools(df_1_bed, df_2_bed):
-    len(df_1_bed.closest(df_2_bed, s=False, t="first"))
+def _write_csv_and_return_count(df: Any) -> int:
+    _write_csv(df)
+    return len(df)
 
 
-def nearest_genomicranges(df_1, df_2, n: int = 1):
-    len(df_1.nearest(df_2, ignore_strand=True, select="arbitrary", num_threads=n))
+def nearest_bioframe(df_1, df_2) -> int:
+    return len(bf.closest(df_1, df_2, cols1=columns, cols2=columns))
 
 
-def overlap_bioframe(df_1, df_2):
-    len(bf.overlap(df_1, df_2, cols1=columns, cols2=columns, how="inner"))
-
-
-def overlap_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.overlap(df_path_1, df_path_2, cols1=columns, cols2=columns)
-        )
-    elif output_type == "datafusion.DataFrame":
-        pb.overlap(
-            df_path_1,
-            df_path_2,
+def nearest_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.nearest(
+            df_1,
+            df_2,
             cols1=columns,
             cols2=columns,
             output_type=output_type,
-        ).count()
-    else:
-        len(
-            pb.overlap(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
-
-
-# Coitrees, IntervalTree, ArrayIntervalTree, Lapper, SuperIntervals
-def overlap_polars_bio_intervaltree(df_path_1, df_path_2, output_type):
-    _collect_lazyframe_count(
-        pb.overlap(
-            df_path_1, df_path_2, cols1=columns, cols2=columns, algorithm="IntervalTree"
-        )
+        ),
+        output_type,
+        consume_mode=consume_mode,
     )
 
 
-def overlap_polars_bio_arrayintervaltree(df_path_1, df_path_2, output_type):
-    _collect_lazyframe_count(
+def nearest_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.nearest_ranges(df_2_pr1, preserve_input_order=False))
+
+
+def nearest_pybedtools(df_1_bed, df_2_bed) -> int:
+    return len(df_1_bed.closest(df_2_bed, s=False, t="first"))
+
+
+def nearest_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(
+        df_1.nearest(df_2, ignore_strand=True, select="arbitrary", num_threads=n)
+    )
+
+
+def overlap_bioframe(df_1, df_2) -> int:
+    return len(bf.overlap(df_1, df_2, cols1=columns, cols2=columns, how="inner"))
+
+
+def overlap_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
         pb.overlap(
-            df_path_1,
-            df_path_2,
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
+
+
+def overlap_polars_bio_intervaltree(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.overlap(
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            algorithm="IntervalTree",
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
+
+
+def overlap_polars_bio_arrayintervaltree(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.overlap(
+            df_1,
+            df_2,
             cols1=columns,
             cols2=columns,
             algorithm="ArrayIntervalTree",
-        )
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
     )
 
 
-def overlap_polars_bio_lapper(df_path_1, df_path_2, output_type):
-    _collect_lazyframe_count(
+def overlap_polars_bio_lapper(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
         pb.overlap(
-            df_path_1, df_path_2, cols1=columns, cols2=columns, algorithm="Lapper"
-        )
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            algorithm="Lapper",
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
     )
 
 
-def overlap_polars_bio_superintervals(df_path_1, df_path_2, output_type):
-    _collect_lazyframe_count(
+def overlap_polars_bio_superintervals(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
         pb.overlap(
-            df_path_1,
-            df_path_2,
+            df_1,
+            df_2,
             cols1=columns,
             cols2=columns,
             algorithm="SuperIntervals",
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
+
+
+def overlap_pyranges1_join_overlaps(df_1_pr1, df_2_pr1) -> int:
+    return len(
+        df_1_pr1.join_overlaps(
+            df_2_pr1,
+            multiple="all",
+            preserve_input_order=False,
         )
     )
 
 
-def overlap_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.join_overlaps(df_2_pr1))
+def overlap_pyranges1_overlap(df_1_pr1, df_2_pr1) -> int:
+    return len(
+        df_1_pr1.overlap(
+            df_2_pr1,
+            multiple=True,
+            preserve_input_order=False,
+        )
+    )
 
 
-def overlap_pybedtools(df_1_bed, df_2_bed):
-    len(df_1_bed.intersect(df_2_bed, wa=True, wb=True))
+def overlap_pybedtools(df_1_bed, df_2_bed) -> int:
+    return len(df_1_bed.intersect(df_2_bed, wa=True, wb=True))
 
 
-def overlap_pygenomics(df_1_pg, df_2_array):
-    len(
+def overlap_pygenomics(df_1_pg, df_2_array) -> int:
+    return len(
         list(
             itertools.chain.from_iterable(
                 [df_1_pg.find_all((r[0], r[1], r[2])) for r in df_2_array]
@@ -143,372 +249,368 @@ def overlap_pygenomics(df_1_pg, df_2_array):
     )
 
 
-def overlap_genomicranges(df_1, df_2, n: int = 1):
-    len(df_1.find_overlaps(df_2, ignore_strand=True, query_type="any", num_threads=n))
-
-
-def count_overlaps_polars_bio_mz(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        print(
-            int(
-                pb.count_overlaps(
-                    df_path_1,
-                    df_path_2,
-                    cols1=columns,
-                    cols2=columns,
-                    naive_query=False,
-                )
-                .count()
-                .collect()
-                .rows()[0][0]
-            )
-        )
-    else:
-        len(
-            pb.count_overlaps(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
-
-
-def count_overlaps_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        print(
-            int(
-                pb.count_overlaps(
-                    df_path_1,
-                    df_path_2,
-                    cols1=columns,
-                    cols2=columns,
-                    naive_query=True,
-                )
-                .count()
-                .collect()
-                .rows()[0][0]
-            )
-        )
-    else:
-        len(
-            pb.count_overlaps(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
-
-
-def count_overlaps_bioframe(df_1, df_2):
-    print(len(bf.count_overlaps(df_1, df_2, cols1=columns, cols2=columns)))
-
-
-def count_overlaps_pyranges1(df_1_pr1, df_2_pr1):
-    print(len(df_1_pr1.count_overlaps(df_2_pr1)))
-
-
-def count_overlaps_pybedtools(df_1_bed, df_2_bed):
-    print(len(df_1_bed.intersect(df_2_bed, wa=True, c=True)))
-
-
-def count_overlaps_genomicranges(df_1, df_2, n: int = 1):
-    print(
-        len(
-            df_1.count_overlaps(
-                df_2, ignore_strand=True, query_type="any", num_threads=n
-            )
-        )
+def overlap_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(
+        df_1.find_overlaps(df_2, ignore_strand=True, query_type="any", num_threads=n)
     )
 
 
-def merge_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.merge(df_path_1, cols=columns, output_type=output_type)
-        )
-    else:
-        len(pb.merge(df_path_1, cols=columns, output_type=output_type))
+def count_overlaps_polars_bio_mz(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.count_overlaps(
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            naive_query=False,
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def merge_bioframe(df_1, df_2):
-    len(bf.merge(df_1, cols=columns, min_dist=None))
+def count_overlaps_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.count_overlaps(
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            naive_query=True,
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def merge_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.merge_overlaps())
+def count_overlaps_bioframe(df_1, df_2) -> int:
+    return len(bf.count_overlaps(df_1, df_2, cols1=columns, cols2=columns))
 
 
-def merge_genomicranges(df_1, df_2, n: int = 1):
-    len(df_1.reduce(ignore_strand=True))
+def count_overlaps_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.count_overlaps(df_2_pr1))
 
 
-def cluster_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.cluster(df_path_1, cols=columns, output_type=output_type)
-        )
-    else:
-        len(pb.cluster(df_path_1, cols=columns, output_type=output_type))
+def count_overlaps_pybedtools(df_1_bed, df_2_bed) -> int:
+    return len(df_1_bed.intersect(df_2_bed, wa=True, c=True))
 
 
-def cluster_bioframe(df_1, df_2):
-    len(bf.cluster(df_1, cols=columns, min_dist=None))
+def count_overlaps_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(
+        df_1.count_overlaps(df_2, ignore_strand=True, query_type="any", num_threads=n)
+    )
 
 
-def cluster_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.cluster_overlaps())
+def merge_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.merge(df_1, cols=columns, output_type=output_type),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def complement_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.complement(df_path_1, cols=columns, output_type=output_type)
-        )
-    else:
-        len(pb.complement(df_path_1, cols=columns, output_type=output_type))
+def merge_bioframe(df_1, df_2) -> int:
+    return len(bf.merge(df_1, cols=columns, min_dist=None))
 
 
-def complement_bioframe(df_1, df_2):
-    len(bf.complement(df_1, cols=columns))
+def merge_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.merge_overlaps())
 
 
-def complement_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.complement_ranges())
+def merge_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(df_1.reduce(ignore_strand=True))
 
 
-def complement_genomicranges(df_1, df_2, n: int = 1):
-    len(df_1.gaps(ignore_strand=True))
+def cluster_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.cluster(df_1, cols=columns, output_type=output_type),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def subtract_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.subtract(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
-    else:
-        len(
-            pb.subtract(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
+def cluster_bioframe(df_1, df_2) -> int:
+    return len(bf.cluster(df_1, cols=columns, min_dist=None))
 
 
-def subtract_bioframe(df_1, df_2):
-    len(bf.subtract(df_1, df_2, cols1=columns, cols2=columns))
+def cluster_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.cluster_overlaps())
 
 
-def subtract_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.subtract_overlaps(df_2_pr1))
+def complement_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.complement(df_1, cols=columns, output_type=output_type),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def subtract_genomicranges(df_1, df_2, n: int = 1):
-    len(df_1.subtract(df_2, ignore_strand=True))
+def complement_bioframe(df_1, df_2) -> int:
+    return len(bf.complement(df_1, cols=columns))
 
 
-def coverage_polars_bio(df_path_1, df_path_2, output_type):
-    if output_type == "polars.LazyFrame":
-        _collect_lazyframe_count(
-            pb.coverage(df_path_1, df_path_2, cols1=columns, cols2=columns)
-        )
-    else:
-        len(
-            pb.coverage(
-                df_path_1,
-                df_path_2,
-                cols1=columns,
-                cols2=columns,
-                output_type=output_type,
-            )
-        )
+def complement_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.complement_ranges())
 
 
-def coverage_bioframe(df_1, df_2):
-    len(bf.coverage(df_1, df_2, cols1=columns, cols2=columns))
+def complement_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(df_1.gaps(ignore_strand=True))
 
 
-def coverage_pyranges1(df_1_pr1, df_2_pr1):
-    len(df_1_pr1.count_overlaps(df_2_pr1, calculate_coverage=True))
+def subtract_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.subtract(
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
 
-def coverage_genomicranges(df_1, df_2, n: int = 1):
-    len(df_2.coverage())
+def subtract_bioframe(df_1, df_2) -> int:
+    return len(bf.subtract(df_1, df_2, cols1=columns, cols2=columns))
 
 
-def coverage_pybedtools(df_1_bed, df_2_bed):
-    len(df_1_bed.coverage(df_2_bed, counts=True))
+def subtract_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.subtract_overlaps(df_2_pr1))
 
 
-## Input file formats benchmarking
-def read_vcf_polars_bio(df_path_1, th=1):
-    _collect_lazyframe_count(pb.read_vcf(df_path_1, thread_num=th))
+def subtract_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(df_1.subtract(df_2, ignore_strand=True))
 
 
-## E2E overlap and export to csv
-OUTPUT_CSV = "/tmp/output.csv"
+def coverage_polars_bio(
+    df_1,
+    df_2,
+    output_type: str,
+    consume_mode: str = "count",
+) -> int:
+    return _consume_polars_bio_result(
+        pb.coverage(
+            df_1,
+            df_2,
+            cols1=columns,
+            cols2=columns,
+            output_type=output_type,
+        ),
+        output_type,
+        consume_mode=consume_mode,
+    )
 
-fp = open("memory_profiler_polars_bio.log", "w+")
+
+def coverage_bioframe(df_1, df_2) -> int:
+    return len(bf.coverage(df_1, df_2, cols1=columns, cols2=columns))
 
 
-@profile(stream=fp)
-def e2e_overlap_polars_bio(df_path_1, df_path_2, output_type=None):
+def coverage_pyranges1(df_1_pr1, df_2_pr1) -> int:
+    return len(df_1_pr1.count_overlaps(df_2_pr1, calculate_coverage=True))
+
+
+def coverage_genomicranges(df_1, df_2, n: int = 1) -> int:
+    return len(df_2.coverage())
+
+
+def coverage_pybedtools(df_1_bed, df_2_bed) -> int:
+    return len(df_1_bed.coverage(df_2_bed, counts=True))
+
+
+def read_vcf_polars_bio(df_path_1, th: int = 1, consume_mode: str = "count") -> int:
+    return _consume_polars_bio_result(
+        pb.read_vcf(df_path_1, thread_num=th),
+        output_type="polars.LazyFrame",
+        consume_mode=consume_mode,
+    )
+
+
+polars_bio_profile_fp = open("memory_profiler_polars_bio.log", "w+")
+
+
+@profile(stream=polars_bio_profile_fp)
+def e2e_overlap_polars_bio(df_path_1, df_path_2, output_type=None) -> int:
     df = pb.overlap(df_path_1, df_path_2, cols1=columns, cols2=columns).collect()
-    df.write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_nearest_polars_bio(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_profile_fp)
+def e2e_nearest_polars_bio(df_path_1, df_path_2, output_type=None) -> int:
     df = pb.nearest(df_path_1, df_path_2, cols1=columns, cols2=columns).collect()
-    df.write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_coverage_polars_bio(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_profile_fp)
+def e2e_coverage_polars_bio(df_path_1, df_path_2, output_type=None) -> int:
     df = pb.coverage(df_path_1, df_path_2, cols1=columns, cols2=columns).collect()
-    df.write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_count_overlaps_polars_bio(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_profile_fp)
+def e2e_count_overlaps_polars_bio(df_path_1, df_path_2, output_type=None) -> int:
     df = pb.count_overlaps(df_path_1, df_path_2, cols1=columns, cols2=columns).collect()
-    df.write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-fp = open("memory_profiler_polars_bio.log", "w+")
+polars_bio_streaming_profile_fp = open("memory_profiler_polars_bio.log", "w+")
 
 
-@profile(stream=fp)
+@profile(stream=polars_bio_streaming_profile_fp)
 def e2e_overlap_polars_bio_streaming(
-    df_path_1, df_path_2, output_type=None, low_memory=False
-):
+    df_path_1, df_path_2, output_type=None, low_memory: bool = False
+) -> None:
     if low_memory:
         pb.overlap(
             df_path_1, df_path_2, cols1=columns, cols2=columns, low_memory=True
         ).sink_csv(OUTPUT_CSV)
-    else:
-        pb.overlap(
-            df_path_1, df_path_2, cols1=columns, cols2=columns, streaming=True
-        ).sink_csv(OUTPUT_CSV)
+        return
+    pb.overlap(
+        df_path_1, df_path_2, cols1=columns, cols2=columns, streaming=True
+    ).sink_csv(OUTPUT_CSV)
 
 
-@profile(stream=fp)
-def e2e_nearest_polars_bio_streaming(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_streaming_profile_fp)
+def e2e_nearest_polars_bio_streaming(df_path_1, df_path_2, output_type=None) -> None:
     pb.nearest(df_path_1, df_path_2, cols1=columns, cols2=columns).sink_csv(OUTPUT_CSV)
 
 
-@profile(stream=fp)
-def e2e_coverage_polars_bio_streaming(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_streaming_profile_fp)
+def e2e_coverage_polars_bio_streaming(df_path_1, df_path_2, output_type=None) -> None:
     pb.coverage(df_path_1, df_path_2, cols1=columns, cols2=columns).sink_csv(OUTPUT_CSV)
 
 
-@profile(stream=fp)
-def e2e_count_overlaps_polars_bio_streaming(df_path_1, df_path_2, output_type=None):
+@profile(stream=polars_bio_streaming_profile_fp)
+def e2e_count_overlaps_polars_bio_streaming(
+    df_path_1, df_path_2, output_type=None
+) -> None:
     pb.count_overlaps(df_path_1, df_path_2, cols1=columns, cols2=columns).sink_csv(
         OUTPUT_CSV
     )
 
 
-fp = open("memory_profiler_bioframe.log", "w+")
+bioframe_profile_fp = open("memory_profiler_bioframe.log", "w+")
 
 
-@profile(stream=fp)
-def e2e_overlap_bioframe(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=bioframe_profile_fp)
+def e2e_overlap_bioframe(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df = bf.overlap(df_1, df_2, cols1=columns, cols2=columns, how="inner")
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_nearest_bioframe(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=bioframe_profile_fp)
+def e2e_nearest_bioframe(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df = bf.closest(df_1, df_2, cols1=columns, cols2=columns)
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_coverage_bioframe(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=bioframe_profile_fp)
+def e2e_coverage_bioframe(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df = bf.coverage(df_1, df_2, cols1=columns, cols2=columns)
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_count_overlaps_bioframe(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=bioframe_profile_fp)
+def e2e_count_overlaps_bioframe(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df = bf.count_overlaps(df_1, df_2, cols1=columns, cols2=columns)
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-fp = open("memory_profiler_pyranges1.log", "w+")
+pyranges1_profile_fp = open("memory_profiler_pyranges1.log", "w+")
 
 
-@profile(stream=fp)
-def e2e_overlap_pyranges1(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=pyranges1_profile_fp)
+def e2e_overlap_pyranges1(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df_1_pr1 = df2pr1(df_1)
     df_2_pr1 = df2pr1(df_2)
-    df = df_1_pr1.join_overlaps(df_2_pr1)
-    df.to_csv("output.csv")
+    df = df_1_pr1.join_overlaps(
+        df_2_pr1,
+        multiple="all",
+        preserve_input_order=False,
+    )
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_nearest_pyranges1(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=pyranges1_profile_fp)
+def e2e_nearest_pyranges1(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df_1_pr1 = df2pr1(df_1)
     df_2_pr1 = df2pr1(df_2)
-    df = df_1_pr1.nearest_ranges(df_2_pr1)
-    df.to_csv("output.csv")
+    df = df_1_pr1.nearest_ranges(df_2_pr1, preserve_input_order=False)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_coverage_pyranges1(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=pyranges1_profile_fp)
+def e2e_coverage_pyranges1(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df_1_pr1 = df2pr1(df_1)
     df_2_pr1 = df2pr1(df_2)
     df = df_1_pr1.count_overlaps(df_2_pr1, calculate_coverage=True)
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_count_overlaps_pyranges1(df_path_1, df_path_2):
-    df_1 = pd.read_parquet(df_path_1.replace("*.parquet", ""))
-    df_2 = pd.read_parquet(df_path_2.replace("*.parquet", ""))
+@profile(stream=pyranges1_profile_fp)
+def e2e_count_overlaps_pyranges1(df_path_1, df_path_2) -> int:
+    df_1 = _read_pandas_parquet(df_path_1)
+    df_2 = _read_pandas_parquet(df_path_2)
     df_1_pr1 = df2pr1(df_1)
     df_2_pr1 = df2pr1(df_2)
     df = df_1_pr1.count_overlaps(df_2_pr1)
-    df.to_csv("output.csv")
+    return _write_csv_and_return_count(df)
 
 
-# GenomicRanges E2E tests
-fp = open("memory_profiler_genomicranges.log", "w+")
+genomicranges_profile_fp = open("memory_profiler_genomicranges.log", "w+")
 
 
-@profile(stream=fp)
-def e2e_overlap_genomicranges(df_path_1, df_path_2, n: int = 1):
-    df_1 = pl.read_parquet(df_path_1)
-    df_2 = pl.read_parquet(df_path_2) if df_path_2 else None
-    df_1_gr = GenomicRanges.from_polars(
-        df_1.rename(
+def _to_genomicranges(df: pl.DataFrame | None):
+    if df is None:
+        return None
+    return GenomicRanges.from_polars(
+        df.rename(
             {
                 "contig": "seqnames",
                 "pos_start": "starts",
@@ -516,84 +618,43 @@ def e2e_overlap_genomicranges(df_path_1, df_path_2, n: int = 1):
             }
         )
     )
-    df_2_gr = (
-        GenomicRanges.from_polars(
-            df_2.rename(
-                {
-                    "contig": "seqnames",
-                    "pos_start": "starts",
-                    "pos_end": "ends",
-                }
-            )
-        )
-        if df_2 is not None
-        else None
-    )
+
+
+@profile(stream=genomicranges_profile_fp)
+def e2e_overlap_genomicranges(df_path_1, df_path_2, n: int = 1) -> int:
+    df_1 = pl.read_parquet(df_path_1)
+    df_2 = pl.read_parquet(df_path_2) if df_path_2 else None
+    df_1_gr = _to_genomicranges(df_1)
+    df_2_gr = _to_genomicranges(df_2)
     hits = df_1_gr.find_overlaps(
         df_2_gr, ignore_strand=True, query_type="any", num_threads=n
     )
     df = overlaps_to_df(df_1_gr, df_2_gr, hits, backend="polars")
-    df.write_csv(OUTPUT_CSV)
-    # hits.to_polars().write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_nearest_genomicranges(df_path_1, df_path_2, n: int = 1):
+@profile(stream=genomicranges_profile_fp)
+def e2e_nearest_genomicranges(df_path_1, df_path_2, n: int = 1) -> int:
     df_1 = pl.read_parquet(df_path_1)
     df_2 = pl.read_parquet(df_path_2) if df_path_2 else None
-    df_1_gr = GenomicRanges.from_polars(
-        df_1.rename(
-            {
-                "contig": "seqnames",
-                "pos_start": "starts",
-                "pos_end": "ends",
-            }
-        )
+    df_1_gr = _to_genomicranges(df_1)
+    df_2_gr = _to_genomicranges(df_2)
+    df = df_1_gr.nearest(
+        df_2_gr,
+        ignore_strand=True,
+        select="arbitrary",
+        num_threads=n,
     )
-    df_2_gr = (
-        GenomicRanges.from_polars(
-            df_2.rename(
-                {
-                    "contig": "seqnames",
-                    "pos_start": "starts",
-                    "pos_end": "ends",
-                }
-            )
-        )
-        if df_2 is not None
-        else None
-    )
-    df = df_1_gr.nearest(df_2_gr, ignore_strand=True, select="arbitrary", num_threads=n)
-    df.to_polars().write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)
 
 
-@profile(stream=fp)
-def e2e_count_overlaps_genomicranges(df_path_1, df_path_2, n: int = 1):
+@profile(stream=genomicranges_profile_fp)
+def e2e_count_overlaps_genomicranges(df_path_1, df_path_2, n: int = 1) -> int:
     df_1 = pl.read_parquet(df_path_1)
     df_2 = pl.read_parquet(df_path_2) if df_path_2 else None
-    df_1_gr = GenomicRanges.from_polars(
-        df_1.rename(
-            {
-                "contig": "seqnames",
-                "pos_start": "starts",
-                "pos_end": "ends",
-            }
-        )
-    )
-    df_2_gr = (
-        GenomicRanges.from_polars(
-            df_2.rename(
-                {
-                    "contig": "seqnames",
-                    "pos_start": "starts",
-                    "pos_end": "ends",
-                }
-            )
-        )
-        if df_2 is not None
-        else None
-    )
+    df_1_gr = _to_genomicranges(df_1)
+    df_2_gr = _to_genomicranges(df_2)
     df = df_1_gr.count_overlaps(
         df_2_gr, ignore_strand=True, query_type="any", num_threads=n
     )
-    df.to_polars().write_csv(OUTPUT_CSV)
+    return _write_csv_and_return_count(df)

--- a/src/run-benchmarks.py
+++ b/src/run-benchmarks.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import time
 import timeit
@@ -66,6 +67,9 @@ class TestCaseInputs:
         self.df_path_2 = df_path_2
         self.coordinate_system_zero_based = coordinate_system_zero_based
         self._pandas_frames: tuple[pd.DataFrame, pd.DataFrame | None] | None = None
+        self._pandas_pyarrow_frames: tuple[pd.DataFrame, pd.DataFrame | None] | None = (
+            None
+        )
         self._polars_frames: tuple[pl.DataFrame, pl.DataFrame | None] | None = None
         self._polars_lazy_frames: tuple[pl.LazyFrame, pl.LazyFrame | None] | None = None
         self._pyranges_frames = None
@@ -89,6 +93,26 @@ class TestCaseInputs:
                 ),
             )
         return self._pandas_frames
+
+    def pandas_pyarrow_frames(self) -> tuple[pd.DataFrame, pd.DataFrame | None]:
+        if self._pandas_pyarrow_frames is None:
+            self._pandas_pyarrow_frames = (
+                _set_polars_bio_coordinate_system(
+                    _read_pandas_parquet(
+                        self.df_path_1,
+                        dtype_backend="pyarrow",
+                    ),
+                    self.coordinate_system_zero_based,
+                ),
+                _set_polars_bio_coordinate_system(
+                    _read_pandas_parquet(
+                        self.df_path_2,
+                        dtype_backend="pyarrow",
+                    ),
+                    self.coordinate_system_zero_based,
+                ),
+            )
+        return self._pandas_pyarrow_frames
 
     def polars_frames(self) -> tuple[pl.DataFrame, pl.DataFrame | None]:
         if self._polars_frames is None:
@@ -126,6 +150,8 @@ class TestCaseInputs:
             return self.parquet_paths()
         if normalized_input_type == "pandas.DataFrame":
             return self.pandas_frames()
+        if normalized_input_type == "pandas.pyarrow.DataFrame":
+            return self.pandas_pyarrow_frames()
         if normalized_input_type == "polars.DataFrame":
             return self.polars_frames()
         if normalized_input_type == "polars.LazyFrame":
@@ -191,6 +217,10 @@ POLARS_BIO_INPUT_ALIASES = {
     "parquet": "parquet",
     "pandas": "pandas.DataFrame",
     "pandas.DataFrame": "pandas.DataFrame",
+    "pandas.pyarrow": "pandas.pyarrow.DataFrame",
+    "pandas.pyarrow.DataFrame": "pandas.pyarrow.DataFrame",
+    "pandas.PyArrowDataFrame": "pandas.pyarrow.DataFrame",
+    "pandas_arrow": "pandas.pyarrow.DataFrame",
     "polars": "polars.DataFrame",
     "polars.DataFrame": "polars.DataFrame",
     "polars.LazyFrame": "polars.LazyFrame",
@@ -344,11 +374,21 @@ def _pandas_parquet_path(path: str | None) -> str | None:
     return path.replace("*.parquet", "")
 
 
-def _read_pandas_parquet(path: str | None) -> pd.DataFrame | None:
+def _read_pandas_parquet(
+    path: str | None,
+    dtype_backend: str | None = None,
+) -> pd.DataFrame | None:
     parquet_path = _pandas_parquet_path(path)
     if parquet_path is None:
         return None
-    return pd.read_parquet(parquet_path, engine="pyarrow")
+    read_parquet_kwargs: dict[str, Any] = {"engine": "pyarrow"}
+    if dtype_backend is not None:
+        if "dtype_backend" not in inspect.signature(pd.read_parquet).parameters:
+            raise RuntimeError(
+                "pandas parquet Arrow dtype backend requires pandas read_parquet(dtype_backend=...) support"
+            )
+        read_parquet_kwargs["dtype_backend"] = dtype_backend
+    return pd.read_parquet(parquet_path, **read_parquet_kwargs)
 
 
 def _read_polars_parquet(path: str | None) -> pl.DataFrame | None:
@@ -392,6 +432,7 @@ def normalize_polars_bio_input_type(input_type: str | None) -> str:
     supported_input_types = {
         "parquet",
         "pandas.DataFrame",
+        "pandas.pyarrow.DataFrame",
         "polars.DataFrame",
         "polars.LazyFrame",
     }

--- a/src/run-benchmarks.py
+++ b/src/run-benchmarks.py
@@ -1,6 +1,8 @@
 import os
 import time
 import timeit
+from dataclasses import dataclass
+from typing import Any, Callable
 
 import click
 import emoji
@@ -9,515 +11,909 @@ import pandas as pd
 import polars as pl
 import polars_bio as pb
 import pybedtools
-import rich
 import yaml
 from genomicranges import GenomicRanges
+from polars_bio._metadata import set_coordinate_system
 from pygenomics.interval import GenomicBase
 from rich.box import MARKDOWN
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
-from rich_tools import table_to_df
 from tqdm import tqdm
 
+import operations as ops
 from logger import logger
-from operations import (
-    cluster_bioframe,
-    cluster_polars_bio,
-    cluster_pyranges1,
-    complement_bioframe,
-    complement_genomicranges,
-    complement_polars_bio,
-    complement_pyranges1,
-    count_overlaps_bioframe,
-    count_overlaps_genomicranges,
-    count_overlaps_polars_bio,
-    count_overlaps_pybedtools,
-    count_overlaps_pyranges1,
-    coverage_bioframe,
-    coverage_genomicranges,
-    coverage_polars_bio,
-    coverage_pybedtools,
-    coverage_pyranges1,
-    e2e_count_overlaps_bioframe,
-    e2e_count_overlaps_genomicranges,
-    e2e_count_overlaps_polars_bio,
-    e2e_count_overlaps_polars_bio_streaming,
-    e2e_count_overlaps_pyranges1,
-    e2e_coverage_bioframe,
-    e2e_coverage_polars_bio,
-    e2e_coverage_polars_bio_streaming,
-    e2e_coverage_pyranges1,
-    e2e_nearest_bioframe,
-    e2e_nearest_genomicranges,
-    e2e_nearest_polars_bio,
-    e2e_nearest_polars_bio_streaming,
-    e2e_nearest_pyranges1,
-    e2e_overlap_bioframe,
-    e2e_overlap_genomicranges,
-    e2e_overlap_polars_bio,
-    e2e_overlap_polars_bio_streaming,
-    e2e_overlap_pyranges1,
-    merge_bioframe,
-    merge_genomicranges,
-    merge_polars_bio,
-    merge_pyranges1,
-    nearest_bioframe,
-    nearest_genomicranges,
-    nearest_polars_bio,
-    nearest_pybedtools,
-    nearest_pyranges1,
-    overlap_bioframe,
-    overlap_genomicranges,
-    overlap_polars_bio,
-    overlap_polars_bio_arrayintervaltree,
-    overlap_polars_bio_intervaltree,
-    overlap_polars_bio_lapper,
-    overlap_polars_bio_superintervals,
-    overlap_pybedtools,
-    overlap_pygenomics,
-    overlap_pyranges1,
-    read_vcf_polars_bio,
-    subtract_bioframe,
-    subtract_genomicranges,
-    subtract_polars_bio,
-    subtract_pyranges1,
-)
 from utils import df2pr1, prepare_datatests
 
 
-def run_benchmark(
-    benchmarks,
-    test_cases,
-    functions_overlap,
-    functions_nearest,
-    functions_count_overlaps,
-    functions_merge,
-    functions_cluster,
-    functions_complement,
-    functions_subtract,
-    functions_coverage,
-    functions_read_vcf,
-    functions_e2,
-    bech_data_root,
-    output_dir,
-    baseline,
-    export_format,
-    console=Console(record=True),
-):
-    for b in tqdm(benchmarks, desc="Running benchmarks"):
-        dataset = b["dataset"]
-        operation = b["operation"]
-        num_executions = b["num_executions"]
-        num_repeats = b["num_repeats"]
-        parallel = b["parallel"]
-        threads = b["threads"] if parallel else [1]
-        repartition = b["repartition"] if "repartition" in b else False
-        input_dataframes = b["input_dataframes"]
-        tools = b["tools"]
-        all_algorithms = b["all_algorithms"] if "all_algorithms" in b else False
-        if input_dataframes:
-            dataframes_io = b["dataframes_io"]
-            for d in dataframes_io:
-                tools.append(f"polars_bio_{d}")
-        console.log(
-            f"## Benchmark {b["name"]} for {operation} with dataset {dataset} \n"
+@dataclass(frozen=True)
+class ToolVariant:
+    base_tool: str
+    name: str
+    input_type: str | None = None
+    output_type: str | None = None
+
+
+@dataclass
+class TimedInvocation:
+    func: Callable[[], Any]
+    row_count_fallback: Callable[[], int | None] | None = None
+    last_result: Any = None
+
+    def __call__(self) -> Any:
+        self.last_result = self.func()
+        return self.last_result
+
+    def row_count(self) -> int | None:
+        if self.last_result is not None:
+            return int(self.last_result)
+        if self.row_count_fallback is None:
+            return None
+        row_count = self.row_count_fallback()
+        if row_count is None:
+            return None
+        return int(row_count)
+
+
+class TestCaseInputs:
+    def __init__(
+        self,
+        df_path_1: str | None,
+        df_path_2: str | None,
+        coordinate_system_zero_based: bool = True,
+    ):
+        self.df_path_1 = df_path_1
+        self.df_path_2 = df_path_2
+        self.coordinate_system_zero_based = coordinate_system_zero_based
+        self._pandas_frames: tuple[pd.DataFrame, pd.DataFrame | None] | None = None
+        self._polars_frames: tuple[pl.DataFrame, pl.DataFrame | None] | None = None
+        self._polars_lazy_frames: tuple[pl.LazyFrame, pl.LazyFrame | None] | None = None
+        self._pyranges_frames = None
+        self._pybedtools_frames = None
+        self._pygenomics_frames = None
+        self._genomicranges_frames = None
+
+    def parquet_paths(self) -> tuple[str | None, str | None]:
+        return self.df_path_1, self.df_path_2
+
+    def pandas_frames(self) -> tuple[pd.DataFrame, pd.DataFrame | None]:
+        if self._pandas_frames is None:
+            self._pandas_frames = (
+                _set_polars_bio_coordinate_system(
+                    _read_pandas_parquet(self.df_path_1),
+                    self.coordinate_system_zero_based,
+                ),
+                _set_polars_bio_coordinate_system(
+                    _read_pandas_parquet(self.df_path_2),
+                    self.coordinate_system_zero_based,
+                ),
+            )
+        return self._pandas_frames
+
+    def polars_frames(self) -> tuple[pl.DataFrame, pl.DataFrame | None]:
+        if self._polars_frames is None:
+            self._polars_frames = (
+                _set_polars_bio_coordinate_system(
+                    _read_polars_parquet(self.df_path_1),
+                    self.coordinate_system_zero_based,
+                ),
+                _set_polars_bio_coordinate_system(
+                    _read_polars_parquet(self.df_path_2),
+                    self.coordinate_system_zero_based,
+                ),
+            )
+        return self._polars_frames
+
+    def polars_lazy_frames(self) -> tuple[pl.LazyFrame, pl.LazyFrame | None]:
+        if self._polars_lazy_frames is None:
+            self._polars_lazy_frames = (
+                _set_polars_bio_coordinate_system(
+                    _scan_polars_parquet(self.df_path_1),
+                    self.coordinate_system_zero_based,
+                ),
+                _set_polars_bio_coordinate_system(
+                    _scan_polars_parquet(self.df_path_2),
+                    self.coordinate_system_zero_based,
+                ),
+            )
+        return self._polars_lazy_frames
+
+    def polars_bio_inputs(
+        self, input_type: str | None
+    ) -> tuple[str | pd.DataFrame | pl.DataFrame | pl.LazyFrame | None, Any]:
+        normalized_input_type = normalize_polars_bio_input_type(input_type)
+        if normalized_input_type == "parquet":
+            return self.parquet_paths()
+        if normalized_input_type == "pandas.DataFrame":
+            return self.pandas_frames()
+        if normalized_input_type == "polars.DataFrame":
+            return self.polars_frames()
+        if normalized_input_type == "polars.LazyFrame":
+            return self.polars_lazy_frames()
+        raise ValueError(f"Unsupported polars_bio input type: {normalized_input_type}")
+
+    def pyranges_frames(self):
+        if self._pyranges_frames is None:
+            df_1, df_2 = self.pandas_frames()
+            self._pyranges_frames = (
+                df2pr1(df_1),
+                df2pr1(df_2) if df_2 is not None else None,
+            )
+        return self._pyranges_frames
+
+    def pybedtools_frames(self):
+        if self._pybedtools_frames is None:
+            df_1, df_2 = self.pandas_frames()
+            bed_df_1 = df_1.sort_values(by=["contig", "pos_start", "pos_end"])
+            bed_df_2 = (
+                df_2.sort_values(by=["contig", "pos_start", "pos_end"])
+                if df_2 is not None
+                else None
+            )
+            self._pybedtools_frames = (
+                pybedtools.BedTool.from_dataframe(bed_df_1),
+                (
+                    pybedtools.BedTool.from_dataframe(bed_df_2)
+                    if bed_df_2 is not None
+                    else None
+                ),
+            )
+        return self._pybedtools_frames
+
+    def pygenomics_frames(self):
+        if self._pygenomics_frames is None:
+            df_1, df_2 = self.pandas_frames()
+            self._pygenomics_frames = (
+                GenomicBase(
+                    [
+                        (row.contig, row.pos_start, row.pos_end)
+                        for row in df_1.itertuples()
+                    ]
+                ),
+                df_2.values.tolist() if df_2 is not None else None,
+            )
+        return self._pygenomics_frames
+
+    def genomicranges_frames(self):
+        if self._genomicranges_frames is None:
+            df_1, df_2 = self.pandas_frames()
+            self._genomicranges_frames = (
+                _to_genomicranges(df_1),
+                _to_genomicranges(df_2),
+            )
+        return self._genomicranges_frames
+
+
+POLARS_BIO_INPUT_ALIASES = {
+    None: "parquet",
+    "path": "parquet",
+    "parquet_path": "parquet",
+    "parquet": "parquet",
+    "pandas": "pandas.DataFrame",
+    "pandas.DataFrame": "pandas.DataFrame",
+    "polars": "polars.DataFrame",
+    "polars.DataFrame": "polars.DataFrame",
+    "polars.LazyFrame": "polars.LazyFrame",
+    "lazy": "polars.LazyFrame",
+}
+
+
+POLARS_BIO_COORDINATE_SYSTEM_ALIASES = {
+    None: True,
+    True: True,
+    False: False,
+    "0-based": True,
+    "0_based": True,
+    "0based": True,
+    "zero-based": True,
+    "zero_based": True,
+    "zero based": True,
+    "zero": True,
+    "0": True,
+    "true": True,
+    "1-based": False,
+    "1_based": False,
+    "1based": False,
+    "one-based": False,
+    "one_based": False,
+    "one based": False,
+    "one": False,
+    "1": False,
+    "false": False,
+}
+
+
+POLARS_BIO_CONSUME_MODE_ALIASES = {
+    None: "count",
+    "count": "count",
+    "len": "len",
+    "length": "len",
+    "materialize": "len",
+}
+
+
+NON_PARALLEL_TOOLS = {"bioframe", "pyranges1", "pybedtools", "pygenomics"}
+
+
+OPERATION_FUNCTIONS = {
+    "overlap": {
+        "polars_bio": [
+            ops.overlap_polars_bio,
+            ops.overlap_polars_bio_intervaltree,
+            ops.overlap_polars_bio_arrayintervaltree,
+            ops.overlap_polars_bio_lapper,
+            ops.overlap_polars_bio_superintervals,
+        ],
+        "bioframe": [ops.overlap_bioframe],
+        "pyranges1": [
+            ops.overlap_pyranges1_join_overlaps,
+            ops.overlap_pyranges1_overlap,
+        ],
+        "pybedtools": [ops.overlap_pybedtools],
+        "pygenomics": [ops.overlap_pygenomics],
+        "genomicranges": [ops.overlap_genomicranges],
+    },
+    "nearest": {
+        "polars_bio": [ops.nearest_polars_bio],
+        "bioframe": [ops.nearest_bioframe],
+        "pyranges1": [ops.nearest_pyranges1],
+        "pybedtools": [ops.nearest_pybedtools],
+        "genomicranges": [ops.nearest_genomicranges],
+    },
+    "count_overlaps": {
+        "polars_bio": [ops.count_overlaps_polars_bio],
+        "bioframe": [ops.count_overlaps_bioframe],
+        "pyranges1": [ops.count_overlaps_pyranges1],
+        "pybedtools": [ops.count_overlaps_pybedtools],
+        "genomicranges": [ops.count_overlaps_genomicranges],
+    },
+    "merge": {
+        "polars_bio": [ops.merge_polars_bio],
+        "bioframe": [ops.merge_bioframe],
+        "pyranges1": [ops.merge_pyranges1],
+        "genomicranges": [ops.merge_genomicranges],
+    },
+    "cluster": {
+        "polars_bio": [ops.cluster_polars_bio],
+        "bioframe": [ops.cluster_bioframe],
+        "pyranges1": [ops.cluster_pyranges1],
+    },
+    "complement": {
+        "polars_bio": [ops.complement_polars_bio],
+        "bioframe": [ops.complement_bioframe],
+        "pyranges1": [ops.complement_pyranges1],
+        "genomicranges": [ops.complement_genomicranges],
+    },
+    "subtract": {
+        "polars_bio": [ops.subtract_polars_bio],
+        "bioframe": [ops.subtract_bioframe],
+        "pyranges1": [ops.subtract_pyranges1],
+        "genomicranges": [ops.subtract_genomicranges],
+    },
+    "coverage": {
+        "polars_bio": [ops.coverage_polars_bio],
+        "bioframe": [ops.coverage_bioframe],
+        "pyranges1": [ops.coverage_pyranges1],
+        "pybedtools": [ops.coverage_pybedtools],
+        "genomicranges": [ops.coverage_genomicranges],
+    },
+    "read_vcf": {
+        "polars_bio": [ops.read_vcf_polars_bio],
+    },
+    "e2e_overlap": {
+        "polars_bio": [
+            ops.e2e_overlap_polars_bio,
+            ops.e2e_overlap_polars_bio_streaming,
+        ],
+        "bioframe": [ops.e2e_overlap_bioframe],
+        "pyranges1": [ops.e2e_overlap_pyranges1],
+        "genomicranges": [ops.e2e_overlap_genomicranges],
+    },
+    "e2e_nearest": {
+        "polars_bio": [
+            ops.e2e_nearest_polars_bio,
+            ops.e2e_nearest_polars_bio_streaming,
+        ],
+        "bioframe": [ops.e2e_nearest_bioframe],
+        "pyranges1": [ops.e2e_nearest_pyranges1],
+        "genomicranges": [ops.e2e_nearest_genomicranges],
+    },
+    "e2e_coverage": {
+        "polars_bio": [
+            ops.e2e_coverage_polars_bio,
+            ops.e2e_coverage_polars_bio_streaming,
+        ],
+        "bioframe": [ops.e2e_coverage_bioframe],
+        "pyranges1": [ops.e2e_coverage_pyranges1],
+    },
+    "e2e_count_overlaps": {
+        "polars_bio": [
+            ops.e2e_count_overlaps_polars_bio,
+            ops.e2e_count_overlaps_polars_bio_streaming,
+        ],
+        "bioframe": [ops.e2e_count_overlaps_bioframe],
+        "pyranges1": [ops.e2e_count_overlaps_pyranges1],
+        "genomicranges": [ops.e2e_count_overlaps_genomicranges],
+    },
+}
+
+
+def _pandas_parquet_path(path: str | None) -> str | None:
+    if path is None:
+        return None
+    return path.replace("*.parquet", "")
+
+
+def _read_pandas_parquet(path: str | None) -> pd.DataFrame | None:
+    parquet_path = _pandas_parquet_path(path)
+    if parquet_path is None:
+        return None
+    return pd.read_parquet(parquet_path, engine="pyarrow")
+
+
+def _read_polars_parquet(path: str | None) -> pl.DataFrame | None:
+    if path is None:
+        return None
+    return pl.read_parquet(path)
+
+
+def _scan_polars_parquet(path: str | None) -> pl.LazyFrame | None:
+    if path is None:
+        return None
+    return pl.scan_parquet(path)
+
+
+def _to_genomicranges(df: pd.DataFrame | None):
+    if df is None:
+        return None
+    return GenomicRanges.from_pandas(
+        df.rename(
+            columns={
+                "contig": "seqnames",
+                "pos_start": "starts",
+                "pos_end": "ends",
+            }
         )
-        logger.info(emoji.emojize(f"Running benchmark {b["name"]} :racing_car: "))
-        # share settings across benchmarks
-        pb.set_option("datafusion.execution.batch_size", str(1 * 65536))
-        for t in tqdm(b["test-cases"]):
-            results = []
-            for th in threads:
-                if operation not in ["read_vcf"]:
-                    pb.set_option("datafusion.execution.target_partitions", str(th))
-                if th == 1:
-                    pb.set_option("datafusion.optimizer.repartition_joins", "false")
-                    pb.set_option(
-                        "datafusion.optimizer.repartition_file_scans", "false"
+    )
+
+
+def _set_polars_bio_coordinate_system(
+    df: pd.DataFrame | pl.DataFrame | pl.LazyFrame | None,
+    zero_based: bool,
+):
+    if df is None:
+        return None
+    set_coordinate_system(df, zero_based=zero_based)
+    return df
+
+
+def normalize_polars_bio_input_type(input_type: str | None) -> str:
+    normalized_input_type = POLARS_BIO_INPUT_ALIASES.get(input_type, input_type)
+    supported_input_types = {
+        "parquet",
+        "pandas.DataFrame",
+        "polars.DataFrame",
+        "polars.LazyFrame",
+    }
+    if normalized_input_type not in supported_input_types:
+        raise ValueError(f"Unsupported polars_bio input type: {input_type}")
+    return normalized_input_type
+
+
+def normalize_polars_bio_coordinate_system(value: Any) -> bool:
+    if isinstance(value, str):
+        normalized_value = value.strip().lower()
+    else:
+        normalized_value = value
+
+    coordinate_system_zero_based = POLARS_BIO_COORDINATE_SYSTEM_ALIASES.get(
+        normalized_value
+    )
+    if coordinate_system_zero_based is None:
+        raise ValueError(f"Unsupported polars_bio coordinate system: {value}")
+    return coordinate_system_zero_based
+
+
+def normalize_polars_bio_consume_mode(value: Any) -> str:
+    if isinstance(value, str):
+        normalized_value = value.strip().lower()
+    else:
+        normalized_value = value
+
+    consume_mode = POLARS_BIO_CONSUME_MODE_ALIASES.get(normalized_value)
+    if consume_mode is None:
+        raise ValueError(f"Unsupported polars_bio consume mode: {value}")
+    return consume_mode
+
+
+def parse_polars_bio_io_spec(
+    io_spec: str | dict[str, str],
+    default_output_type: str,
+) -> tuple[str, str]:
+    if isinstance(io_spec, str):
+        input_type, output_type = io_spec.split(":", 1)
+        return normalize_polars_bio_input_type(input_type.strip()), output_type.strip()
+
+    input_type = io_spec.get("input_type") or io_spec.get("input")
+    if input_type is None:
+        raise ValueError(f"Missing input_type in polars_bio IO spec: {io_spec}")
+    output_type = io_spec.get("output_type", default_output_type)
+    return normalize_polars_bio_input_type(input_type), output_type
+
+
+def polars_bio_variant_name(input_type: str, output_type: str) -> str:
+    return f"polars_bio[{input_type}->{output_type}]"
+
+
+def build_tool_variants(
+    benchmark: dict[str, Any],
+    default_polars_bio_output_type: str,
+    console: Console,
+) -> list[ToolVariant]:
+    tool_variants: list[ToolVariant] = []
+    benchmark_output_type = benchmark.get(
+        "polars_bio_output_type",
+        default_polars_bio_output_type,
+    )
+
+    for tool in benchmark["tools"]:
+        if tool == "polars_bio":
+            tool_variants.append(
+                ToolVariant(
+                    base_tool="polars_bio",
+                    name="polars_bio",
+                    input_type="parquet",
+                    output_type=benchmark_output_type,
+                )
+            )
+            if benchmark_output_type != "polars.LazyFrame":
+                console.log(
+                    f":bulb: Benchmark {benchmark['name']} uses polars_bio output_type={benchmark_output_type}"
+                )
+            continue
+        tool_variants.append(ToolVariant(base_tool=tool, name=tool))
+
+    use_dataframe_inputs = (
+        benchmark.get("input_dataframes", False)
+        and not benchmark["operation"].startswith("e2e_")
+        and benchmark["operation"] != "read_vcf"
+    )
+    if not use_dataframe_inputs:
+        return tool_variants
+
+    for io_spec in benchmark.get("dataframes_io", []):
+        input_type, output_type = parse_polars_bio_io_spec(
+            io_spec,
+            benchmark_output_type,
+        )
+        tool_variants.append(
+            ToolVariant(
+                base_tool="polars_bio",
+                name=polars_bio_variant_name(input_type, output_type),
+                input_type=input_type,
+                output_type=output_type,
+            )
+        )
+
+    return tool_variants
+
+
+def select_operation_functions(
+    operation: str,
+    tool: str,
+    all_algorithms: bool,
+) -> list[Callable[..., Any]]:
+    operation_table = OPERATION_FUNCTIONS.get(operation)
+    if operation_table is None:
+        raise ValueError(f"Operation {operation} not found")
+
+    tool_functions = operation_table.get(tool, [])
+    if operation == "overlap" and tool == "polars_bio" and not all_algorithms:
+        return tool_functions[:1]
+    return tool_functions
+
+
+def configure_polars_bio_threads(
+    operation: str,
+    thread_count: int,
+    repartition: bool,
+    coordinate_system_zero_based: bool,
+) -> None:
+    pb.set_option(
+        "datafusion.bio.coordinate_system_zero_based",
+        str(coordinate_system_zero_based).lower(),
+    )
+    if operation != "read_vcf":
+        pb.set_option("datafusion.execution.target_partitions", str(thread_count))
+
+    if thread_count == 1:
+        pb.set_option("datafusion.optimizer.repartition_joins", "false")
+        pb.set_option("datafusion.optimizer.repartition_file_scans", "false")
+        pb.set_option("datafusion.execution.coalesce_batches", "false")
+        return
+
+    if repartition:
+        pb.set_option("datafusion.optimizer.repartition_joins", "true")
+        pb.set_option("datafusion.optimizer.repartition_file_scans", "true")
+        pb.set_option("datafusion.execution.coalesce_batches", "false")
+        return
+
+    pb.set_option("datafusion.optimizer.repartition_joins", "false")
+    pb.set_option("datafusion.optimizer.repartition_file_scans", "false")
+    pb.set_option("datafusion.execution.coalesce_batches", "false")
+
+
+def _csv_output_row_count() -> int | None:
+    if not os.path.exists(ops.OUTPUT_CSV):
+        return None
+    with open(ops.OUTPUT_CSV, "r", encoding="utf-8") as output_file:
+        return max(sum(1 for _ in output_file) - 1, 0)
+
+
+def build_result_name(
+    operation: str,
+    tool_variant: ToolVariant,
+    func: Callable[..., Any],
+    thread_count: int,
+) -> str:
+    func_name = func.__name__.replace(f"{operation}_", "", 1)
+    if func_name == tool_variant.base_tool:
+        result_name = tool_variant.name
+    elif func_name.startswith(f"{tool_variant.base_tool}_"):
+        suffix = func_name.removeprefix(f"{tool_variant.base_tool}_")
+        if "[" in tool_variant.name:
+            prefix, details = tool_variant.name.split("[", 1)
+            result_name = f"{prefix}_{suffix}[{details}"
+        else:
+            result_name = f"{tool_variant.name}_{suffix}"
+    else:
+        result_name = func_name
+
+    if thread_count != 1:
+        return f"{result_name}-{thread_count}"
+    return result_name
+
+
+def build_timed_invocation(
+    operation: str,
+    tool_variant: ToolVariant,
+    func: Callable[..., Any],
+    inputs: TestCaseInputs,
+    thread_count: int,
+    polars_bio_consume_mode: str,
+) -> TimedInvocation | None:
+    if thread_count != 1 and tool_variant.base_tool in NON_PARALLEL_TOOLS:
+        return None
+
+    row_count_fallback = _csv_output_row_count if operation.startswith("e2e_") else None
+
+    if operation == "read_vcf":
+        return TimedInvocation(
+            lambda: func(
+                inputs.df_path_1,
+                th=thread_count,
+                consume_mode=polars_bio_consume_mode,
+            )
+        )
+
+    if tool_variant.base_tool == "polars_bio":
+        df_1, df_2 = inputs.polars_bio_inputs(tool_variant.input_type)
+        return TimedInvocation(
+            lambda: func(
+                df_1,
+                df_2,
+                output_type=tool_variant.output_type,
+                consume_mode=polars_bio_consume_mode,
+            ),
+            row_count_fallback=row_count_fallback,
+        )
+
+    if tool_variant.base_tool == "bioframe":
+        if operation.startswith("e2e_"):
+            df_path_1, df_path_2 = inputs.parquet_paths()
+            return TimedInvocation(
+                lambda: func(df_path_1, df_path_2),
+                row_count_fallback=row_count_fallback,
+            )
+        df_1, df_2 = inputs.pandas_frames()
+        return TimedInvocation(lambda: func(df_1, df_2))
+
+    if tool_variant.base_tool == "pyranges1":
+        if operation.startswith("e2e_"):
+            df_path_1, df_path_2 = inputs.parquet_paths()
+            return TimedInvocation(
+                lambda: func(df_path_1, df_path_2),
+                row_count_fallback=row_count_fallback,
+            )
+        df_1_pr1, df_2_pr1 = inputs.pyranges_frames()
+        return TimedInvocation(lambda: func(df_1_pr1, df_2_pr1))
+
+    if tool_variant.base_tool == "pybedtools":
+        df_1_bed, df_2_bed = inputs.pybedtools_frames()
+        return TimedInvocation(lambda: func(df_1_bed, df_2_bed))
+
+    if tool_variant.base_tool == "pygenomics":
+        df_1_pg, df_2_array = inputs.pygenomics_frames()
+        return TimedInvocation(lambda: func(df_1_pg, df_2_array))
+
+    if tool_variant.base_tool == "genomicranges":
+        if operation.startswith("e2e_"):
+            df_path_1, df_path_2 = inputs.parquet_paths()
+            return TimedInvocation(
+                lambda: func(df_path_1, df_path_2, n=thread_count),
+                row_count_fallback=row_count_fallback,
+            )
+        df_1_gr, df_2_gr = inputs.genomicranges_frames()
+        return TimedInvocation(lambda: func(df_1_gr, df_2_gr, n=thread_count))
+
+    return None
+
+
+def resolve_baseline_mean(results: list[dict[str, Any]], baseline: str) -> float:
+    if baseline == "fastest":
+        return min(result["mean"] for result in results)
+    if baseline == "slowest":
+        return max(result["mean"] for result in results)
+
+    for result in results:
+        if result["name"] == baseline:
+            return result["mean"]
+
+    raise ValueError(f"Baseline '{baseline}' not found in benchmark results")
+
+
+def add_speedups(results: list[dict[str, Any]], baseline: str) -> None:
+    baseline_mean = resolve_baseline_mean(results, baseline)
+    for result in results:
+        result["speedup"] = baseline_mean / result["mean"]
+
+
+def render_results_table(
+    results: list[dict[str, Any]],
+    operation: str,
+    dataset: str,
+    test_name: str,
+) -> Table:
+    table = Table(
+        title=f"Benchmark Results, operation: {operation} dataset: {dataset}, test: {test_name}",
+        box=MARKDOWN,
+    )
+    table.add_column("Library", justify="left", style="cyan")
+    table.add_column("Rows Returned", justify="right", style="yellow")
+    table.add_column("Min (s)", justify="right", style="green")
+    table.add_column("Max (s)", justify="right", style="green")
+    table.add_column("Mean (s)", justify="right", style="green")
+    table.add_column("Speedup", justify="right", style="magenta")
+
+    for result in results:
+        rows_returned = result["rows_returned"]
+        table.add_row(
+            escape(result["name"]),
+            "n/a" if rows_returned is None else f"{rows_returned}",
+            f"{result['min']:.6f}",
+            f"{result['max']:.6f}",
+            f"{result['mean']:.6f}",
+            f"{result['speedup']:.2f}x",
+        )
+
+    return table
+
+
+def export_results(
+    results: list[dict[str, Any]],
+    output_path: str,
+    export_format: str,
+) -> None:
+    result_frame = pd.DataFrame(results)
+    if export_format == "csv":
+        result_frame.to_csv(output_path, index=False)
+
+
+def resolve_test_case_inputs(
+    bench_data_root: str,
+    benchmark_dataset: str,
+    test_case: dict[str, Any],
+    coordinate_system_zero_based: bool,
+) -> tuple[str, TestCaseInputs]:
+    dataset = test_case.get("dataset", benchmark_dataset)
+    df_path_1 = (
+        f"{bench_data_root}/{dataset}/{test_case['df_path_1']}"
+        if "df_path_1" in test_case
+        else None
+    )
+    df_path_2 = (
+        f"{bench_data_root}/{dataset}/{test_case['df_path_2']}"
+        if "df_path_2" in test_case
+        else None
+    )
+    return dataset, TestCaseInputs(
+        df_path_1,
+        df_path_2,
+        coordinate_system_zero_based=coordinate_system_zero_based,
+    )
+
+
+def run_benchmark(
+    benchmarks: list[dict[str, Any]],
+    test_cases: list[dict[str, Any]],
+    bench_data_root: str,
+    output_dir: str,
+    baseline: str,
+    export_format: str,
+    default_polars_bio_output_type: str = "polars.LazyFrame",
+    default_polars_bio_coordinate_system: Any = "0-based",
+    default_polars_bio_consume_mode: Any = "count",
+    console: Console = Console(record=True),
+) -> None:
+    test_cases_by_name = {test_case["name"]: test_case for test_case in test_cases}
+
+    for benchmark in tqdm(benchmarks, desc="Running benchmarks"):
+        benchmark_name = benchmark["name"]
+        benchmark_dataset = benchmark["dataset"]
+        operation = benchmark["operation"]
+        num_executions = benchmark["num_executions"]
+        num_repeats = benchmark["num_repeats"]
+        repartition = benchmark.get("repartition", False)
+        all_algorithms = benchmark.get("all_algorithms", False)
+        coordinate_system_zero_based = normalize_polars_bio_coordinate_system(
+            benchmark.get(
+                "polars_bio_coordinate_system",
+                default_polars_bio_coordinate_system,
+            )
+        )
+        polars_bio_consume_mode = normalize_polars_bio_consume_mode(
+            benchmark.get(
+                "polars_bio_consume_mode",
+                default_polars_bio_consume_mode,
+            )
+        )
+        thread_counts = benchmark["threads"] if benchmark["parallel"] else [1]
+        tool_variants = build_tool_variants(
+            benchmark,
+            default_polars_bio_output_type,
+            console,
+        )
+
+        console.log(
+            f"## Benchmark {benchmark_name} for {operation} with dataset {benchmark_dataset}\n"
+        )
+        logger.info(emoji.emojize(f"Running benchmark {benchmark_name} :racing_car: "))
+
+        pb.set_option("datafusion.execution.batch_size", str(65536))
+
+        for test_name in tqdm(
+            benchmark["test-cases"], desc=f"{benchmark_name} tests", leave=False
+        ):
+            test_case = test_cases_by_name.get(test_name)
+            if test_case is None:
+                logger.warning(
+                    emoji.emojize(
+                        f"Test case {test_name} not found in conf/common.yaml :warning: Skipping."
                     )
-                    pb.set_option("datafusion.execution.coalesce_batches", "false")
-                elif th > 1 and repartition:
-                    pb.set_option("datafusion.optimizer.repartition_joins", "true")
-                    pb.set_option("datafusion.optimizer.repartition_file_scans", "true")
-                    pb.set_option("datafusion.execution.coalesce_batches", "false")
-                else:
-                    pb.set_option("datafusion.optimizer.repartition_joins", "false")
-                    pb.set_option(
-                        "datafusion.optimizer.repartition_file_scans", "false"
-                    )
-                    pb.set_option("datafusion.execution.coalesce_batches", "false")
+                )
+                console.log(f":bulb: Skipping unknown test-case '{test_name}'")
+                continue
+
+            resolved_dataset, inputs = resolve_test_case_inputs(
+                bench_data_root,
+                benchmark_dataset,
+                test_case,
+                coordinate_system_zero_based,
+            )
+            results: list[dict[str, Any]] = []
+
+            for thread_count in thread_counts:
+                configure_polars_bio_threads(
+                    operation,
+                    thread_count,
+                    repartition,
+                    coordinate_system_zero_based,
+                )
                 logger.info(
                     emoji.emojize(
-                        f"Running benchmark {b["name"]} with {th} threads :gear: "
+                        f"Running benchmark {benchmark_name} with {thread_count} threads :gear:"
                     )
                 )
                 logger.info(
-                    emoji.emojize(f"Loading test case {t}... :chequered_flag:  ")
+                    emoji.emojize(f"Loading test case {test_name}... :chequered_flag:")
                 )
-                test_match = [test for test in test_cases if test["name"] == t]
-                if not test_match:
-                    logger.warning(
-                        emoji.emojize(
-                            f"Test case {t} not found in conf/common.yaml :warning: Skipping."
-                        )
-                    )
-                    console.log(f":bulb: Skipping unknown test-case '{t}'")
-                    continue
-                test = test_match[0]
-                df_path_1 = (
-                    f"{bech_data_root}/{dataset}/{test['df_path_1']}"
-                    if "df_path_1" in test
-                    else None
-                )
-                df_path_2 = (
-                    f"{bech_data_root}/{dataset}/{test['df_path_2']}"
-                    if "df_path_2" in test
-                    else None
-                )
-                for tool in tqdm(tools):
+
+                for tool_variant in tqdm(
+                    tool_variants,
+                    desc=f"{test_name} tools",
+                    leave=False,
+                ):
                     logger.info(
                         emoji.emojize(
-                            f"Running benchmark {b["name"]}, test-case {t} for {tool} :hammer_and_wrench:"
+                            f"Running benchmark {benchmark_name}, test-case {test_name} for {tool_variant.name} :hammer_and_wrench:"
                         )
                     )
-                    times = None
-                    func = None
-                    table = None
-                    if operation == "overlap" and not all_algorithms:
-                        table = [
-                            func
-                            for func in functions_overlap
-                            if func.__name__ == f"{operation}_{tool}"
-                        ]
-                    elif operation == "overlap" and all_algorithms:
-                        table = [
-                            func
-                            for func in functions_overlap
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "nearest":
-                        table = [
-                            func
-                            for func in functions_nearest
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "count_overlaps":
-                        table = [
-                            func
-                            for func in functions_count_overlaps
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "merge":
-                        table = [
-                            func
-                            for func in functions_merge
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "cluster":
-                        table = [
-                            func
-                            for func in functions_cluster
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "complement":
-                        table = [
-                            func
-                            for func in functions_complement
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "subtract":
-                        table = [
-                            func
-                            for func in functions_subtract
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "coverage":
-                        table = [
-                            func
-                            for func in functions_coverage
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation == "read_vcf":
-                        table = [
-                            func
-                            for func in functions_read_vcf
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    elif operation in [
-                        "e2e_overlap",
-                        "e2e_nearest",
-                        "e2e_coverage",
-                        "e2e_count_overlaps",
-                    ]:
-                        table = [
-                            func
-                            for func in functions_e2
-                            if func.__name__.startswith(f"{operation}_{tool}")
-                        ]
-                    else:
-                        logger.error(
-                            emoji.emojize(f"Operation {operation} not found :no_entry:")
-                        )
-                        exit(1)
-                    if len(table) == 0:
+
+                    tool_functions = select_operation_functions(
+                        operation,
+                        tool_variant.base_tool,
+                        all_algorithms,
+                    )
+                    if not tool_functions:
                         logger.warning(
                             emoji.emojize(
-                                f"Operation {operation} not found for tool {tool} :no_entry:"
+                                f"Operation {operation} not found for tool {tool_variant.base_tool} :no_entry:"
                             )
                         )
                         console.log(
-                            f":bulb: Tool {tool} does not support operation {operation}"
+                            f":bulb: Tool {tool_variant.base_tool} does not support operation {operation}"
                         )
                         continue
-                    for func in table:
-                        if tool == "polars_bio":
-                            if operation == "read_vcf":
-                                times = timeit.repeat(
-                                    lambda: func(df_path_1, th=th),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                            else:
-                                times = timeit.repeat(
-                                    lambda: func(
-                                        df_path_1,
-                                        df_path_2,
-                                        output_type="polars.LazyFrame",
-                                    ),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                        elif input_dataframes and tool.startswith("polars_bio_"):
-                            input_type = tool.split("_")[2].split(":")[0]
-                            output_type = tool.split("_")[2].split(":")[1]
-                            df_1 = (
-                                pl.read_parquet(df_path_1)
-                                if input_type.startswith("polars")
-                                else pd.read_parquet(df_path_1.replace("*.parquet", ""))
-                            )
-                            df_2 = (
-                                pl.read_parquet(df_path_2)
-                                if input_type.startswith("polars")
-                                else pd.read_parquet(df_path_2.replace("*.parquet", ""))
-                            )
-                            times = timeit.repeat(
-                                lambda: func(df_1, df_2, output_type=output_type),
-                                repeat=num_repeats,
-                                number=num_executions,
-                            )
-                        elif tool == "bioframe" and th == 1:
-                            if operation.startswith("e2e_"):
-                                times = timeit.repeat(
-                                    lambda: func(df_path_1, df_path_2),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                            else:
-                                df_1 = pd.read_parquet(
-                                    df_path_1.replace("*.parquet", ""), engine="pyarrow"
-                                )
-                                df_2 = (
-                                    pd.read_parquet(
-                                        df_path_2.replace("*.parquet", ""),
-                                        engine="pyarrow",
-                                    )
-                                    if df_path_2
-                                    else None
-                                )
-                                times = timeit.repeat(
-                                    lambda: func(df_1, df_2),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                        elif tool == "pyranges1" and th == 1:
-                            if operation.startswith("e2e_"):
-                                times = timeit.repeat(
-                                    lambda: func(df_path_1, df_path_2),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                            else:
-                                df_1 = pd.read_parquet(
-                                    df_path_1.replace("*.parquet", ""), engine="pyarrow"
-                                )
-                                df_2 = (
-                                    pd.read_parquet(
-                                        df_path_2.replace("*.parquet", ""),
-                                        engine="pyarrow",
-                                    )
-                                    if df_path_2
-                                    else None
-                                )
-                                df_1_pr1 = df2pr1(df_1)
-                                df_2_pr1 = df2pr1(df_2) if df_2 is not None else None
-                                times = timeit.repeat(
-                                    lambda: func(df_1_pr1, df_2_pr1),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                        elif tool == "pybedtools" and th == 1:
-                            df_1 = pd.read_parquet(
-                                df_path_1.replace("*.parquet", ""), engine="pyarrow"
-                            ).sort_values(by=["contig", "pos_start", "pos_end"])
-                            df_2 = (
-                                pd.read_parquet(
-                                    df_path_2.replace("*.parquet", ""), engine="pyarrow"
-                                ).sort_values(by=["contig", "pos_start", "pos_end"])
-                                if df_path_2
-                                else None
-                            )
-                            df_1_bed = pybedtools.BedTool.from_dataframe(df_1)
-                            df_2_bed = (
-                                pybedtools.BedTool.from_dataframe(df_2)
-                                if df_2 is not None
-                                else None
-                            )
-                            times = timeit.repeat(
-                                lambda: func(df_1_bed, df_2_bed),
-                                repeat=num_repeats,
-                                number=num_executions,
-                            )
-                        elif tool == "pygenomics" and th == 1:
-                            df_1 = pd.read_parquet(
-                                df_path_1.replace("*.parquet", ""), engine="pyarrow"
-                            )
-                            df_2 = (
-                                pd.read_parquet(
-                                    df_path_2.replace("*.parquet", ""), engine="pyarrow"
-                                )
-                                if df_path_2
-                                else None
-                            )
-                            df_1_pg = GenomicBase(
-                                [
-                                    (r.contig, r.pos_start, r.pos_end)
-                                    for r in df_1.itertuples()
-                                ]
-                            )
-                            df_2_array = (
-                                df_2.values.tolist() if df_2 is not None else None
-                            )
-                            times = timeit.repeat(
-                                lambda: func(df_1_pg, df_2_array),
-                                repeat=num_repeats,
-                                number=num_executions,
-                            )
-                        elif tool == "genomicranges":
-                            if operation.startswith("e2e_"):
-                                times = timeit.repeat(
-                                    lambda: func(df_path_1, df_path_2, n=th),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                            else:
-                                df_1 = pd.read_parquet(
-                                    df_path_1.replace("*.parquet", ""), engine="pyarrow"
-                                )
-                                df_2 = (
-                                    pd.read_parquet(
-                                        df_path_2.replace("*.parquet", ""),
-                                        engine="pyarrow",
-                                    )
-                                    if df_path_2
-                                    else None
-                                )
-                                df_1_gr = GenomicRanges.from_pandas(
-                                    df_1.rename(
-                                        columns={
-                                            "contig": "seqnames",
-                                            "pos_start": "starts",
-                                            "pos_end": "ends",
-                                        }
-                                    )
-                                )
-                                df_2_gr = (
-                                    GenomicRanges.from_pandas(
-                                        df_2.rename(
-                                            columns={
-                                                "contig": "seqnames",
-                                                "pos_start": "starts",
-                                                "pos_end": "ends",
-                                            }
-                                        )
-                                    )
-                                    if df_2 is not None
-                                    else None
-                                )
-                                times = timeit.repeat(
-                                    lambda: func(df_1_gr, df_2_gr, n=th),
-                                    repeat=num_repeats,
-                                    number=num_executions,
-                                )
-                        # elif th == 1:
-                        #     logger.error(
-                        #         emoji.emojize(f"Tool {tool} not found :no_entry:")
-                        #     )
-                        #     exit(1)
-                        else:
+
+                    for func in tool_functions:
+                        invocation = build_timed_invocation(
+                            operation,
+                            tool_variant,
+                            func,
+                            inputs,
+                            thread_count,
+                            polars_bio_consume_mode,
+                        )
+                        if invocation is None:
                             continue
+
+                        timings = timeit.repeat(
+                            invocation,
+                            repeat=num_repeats,
+                            number=num_executions,
+                        )
+                        per_run_timings = [
+                            elapsed / num_executions for elapsed in timings
+                        ]
+
                         logger.info(
                             emoji.emojize(
-                                f"Finished benchmark for {tool} :check_mark_button:"
+                                f"Finished benchmark for {tool_variant.name} :check_mark_button:"
                             )
                         )
-                        per_run_times = [
-                            time / num_executions for time in times
-                        ]  # Convert to per-run times
-                        tool_version = func.__name__.replace(f"{operation}_", "")
+
                         results.append(
                             {
-                                "name": (
-                                    tool_version if th == 1 else f"{tool_version}-{th}"
+                                "name": build_result_name(
+                                    operation,
+                                    tool_variant,
+                                    func,
+                                    thread_count,
                                 ),
-                                "min": min(per_run_times),
-                                "max": max(per_run_times),
-                                "mean": np.mean(per_run_times),
+                                "rows_returned": invocation.row_count(),
+                                "min": min(per_run_timings),
+                                "max": max(per_run_timings),
+                                "mean": float(np.mean(per_run_timings)),
                             }
                         )
-            if baseline == "fastest":
-                baseline_mean = min(result["mean"] for result in results)
-            elif baseline == "slowest":
-                baseline_mean = max(result["mean"] for result in results)
-            else:
-                baseline_mean = [
-                    result["mean"] for result in results if result["name"] == baseline
-                ][0]
 
-            for result in results:
-                result["speedup"] = baseline_mean / result["mean"]
-
-                # Create Rich table
-            table = Table(
-                title=f"Benchmark Results, operation: {operation} dataset: {dataset}, test: {t}",
-                box=MARKDOWN,
-            )
-            table.add_column("Library", justify="left", style="cyan", no_wrap=True)
-            table.add_column("Min (s)", justify="right", style="green")
-            table.add_column("Max (s)", justify="right", style="green")
-            table.add_column("Mean (s)", justify="right", style="green")
-            table.add_column("Speedup", justify="right", style="magenta")
-
-            # Add rows to the table
-            for result in results:
-                table.add_row(
-                    result["name"],
-                    f"{result['min']:.6f}",
-                    f"{result['max']:.6f}",
-                    f"{result['mean']:.6f}",
-                    f"{result['speedup']:.2f}x",
+            if not results:
+                console.log(
+                    f":bulb: No benchmark results collected for {benchmark_name}/{test_name}"
                 )
-            rich.print(table)
-            console.log(table)
-            df = table_to_df(table)
-            table_path = f"{output_dir}/{b["name"]}_{t}.{export_format}"
-            if export_format == "csv":
-                df.to_csv(table_path, index=False)
-            console.save_text(
-                f"{output_dir}/benchmark_results.md", clear=False, styles=False
+                continue
+
+            add_speedups(results, baseline)
+            table = render_results_table(
+                results,
+                operation,
+                resolved_dataset,
+                test_name,
             )
+            console.print(table)
+
+            table_path = f"{output_dir}/{benchmark_name}_{test_name}.{export_format}"
+            export_results(results, table_path, export_format)
+            console.save_text(
+                f"{output_dir}/benchmark_results.md",
+                clear=False,
+                styles=False,
+            )
+
         logger.info(
-            emoji.emojize(f"Finished benchmark {b["name"]} :check_mark_button:")
+            emoji.emojize(f"Finished benchmark {benchmark_name} :check_mark_button:")
         )
+
     console.print("Benchmark results saved to benchmark_results.md")
 
 
@@ -527,150 +923,69 @@ def run_benchmark(
     default="conf/benchmark_small.yaml",
     help="Benchmark config file (default: conf/benchmark_small.yaml)",
 )
-def run(bench_config: str):
+def run(bench_config: str) -> None:
     logger.info(f"Using config file: {bench_config}")
     tag_datetime = time.strftime("%Y-%m-%d %H:%M:%S")
     logger.info(emoji.emojize("Starting polars_bio_benchmark :rocket:"))
-    # create dir recursively
+
     output_dir = f"results/{tag_datetime}"
     os.makedirs(output_dir, exist_ok=True)
 
-    REPORT_FILE = f"{output_dir}/benchmark_results.md"
-    if os.path.exists(REPORT_FILE):
+    report_file = f"{output_dir}/benchmark_results.md"
+    if os.path.exists(report_file):
         logger.info(
             emoji.emojize(
-                f"Performance report file {REPORT_FILE} already exist...quiting. Rename/remove it to re-run the benchmark :wastebasket:"
+                f"Performance report file {report_file} already exist...quiting. Rename/remove it to re-run the benchmark :wastebasket:"
             )
         )
-        exit(1)
-    BECH_DATA_ROOT = os.getenv("BENCH_DATA_ROOT")
-    if not BECH_DATA_ROOT:
+        raise SystemExit(1)
+
+    bench_data_root = os.getenv("BENCH_DATA_ROOT")
+    if not bench_data_root:
         logger.error(
             emoji.emojize("Env variable BENCH_DATA_ROOT is not set :pile_of_poo:")
         )
-        exit(1)
+        raise SystemExit(1)
 
-    with open("conf/common.yaml", "r") as file:
-        config = yaml.safe_load(file)
+    with open("conf/common.yaml", "r", encoding="utf-8") as config_file:
+        common_config = yaml.safe_load(config_file)
     logger.info(emoji.emojize("Loaded config. :open_book:"))
 
-    with open(bench_config, "r") as file:
-        benchmarks = yaml.safe_load(file)
-        logger.info(emoji.emojize("Loaded benchmarks. :open_book:"))
-    datasets = config["datasets"]
-    test_cases = config["test-cases"]
-    baseline = benchmarks["common"]["baseline"].lower()
-    benchmarks = benchmarks["benchmarks"]
-    export_format = config["benchmark"]["export"]["format"].lower()
-    functions_overlap = [
-        overlap_polars_bio,
-        overlap_polars_bio_intervaltree,
-        overlap_polars_bio_arrayintervaltree,
-        overlap_polars_bio_lapper,
-        overlap_polars_bio_superintervals,
-        overlap_bioframe,
-        overlap_pyranges1,
-        overlap_pybedtools,
-        overlap_pygenomics,
-        overlap_genomicranges,
-    ]
+    with open(bench_config, "r", encoding="utf-8") as benchmark_file:
+        benchmark_config = yaml.safe_load(benchmark_file)
+    logger.info(emoji.emojize("Loaded benchmarks. :open_book:"))
 
-    functions_nearest = [
-        nearest_polars_bio,
-        nearest_bioframe,
-        nearest_pyranges1,
-        nearest_pybedtools,
-        nearest_genomicranges,
-    ]
-    functions_count_overlaps = [
-        # count_overlaps_polars_bio_mz,
-        count_overlaps_polars_bio,
-        count_overlaps_bioframe,
-        count_overlaps_pyranges1,
-        count_overlaps_pybedtools,
-        count_overlaps_genomicranges,
-    ]
+    datasets = common_config["datasets"]
+    test_cases = common_config["test-cases"]
+    common_benchmark_config = benchmark_config["common"]
+    baseline = common_benchmark_config["baseline"].lower()
+    default_polars_bio_output_type = common_benchmark_config.get(
+        "polars_bio_output_type",
+        "polars.LazyFrame",
+    )
+    default_polars_bio_coordinate_system = common_benchmark_config.get(
+        "polars_bio_coordinate_system",
+        "0-based",
+    )
+    default_polars_bio_consume_mode = common_benchmark_config.get(
+        "polars_bio_consume_mode",
+        "count",
+    )
+    benchmarks = benchmark_config["benchmarks"]
+    export_format = common_config["benchmark"]["export"]["format"].lower()
 
-    functions_merge = [
-        merge_polars_bio,
-        merge_bioframe,
-        merge_pyranges1,
-        merge_genomicranges,
-    ]
-
-    functions_cluster = [
-        cluster_polars_bio,
-        cluster_bioframe,
-        cluster_pyranges1,
-    ]
-
-    functions_complement = [
-        complement_polars_bio,
-        complement_bioframe,
-        complement_pyranges1,
-        complement_genomicranges,
-    ]
-
-    functions_subtract = [
-        subtract_polars_bio,
-        subtract_bioframe,
-        subtract_pyranges1,
-        subtract_genomicranges,
-    ]
-
-    functions_coverage = [
-        coverage_polars_bio,
-        coverage_bioframe,
-        coverage_pyranges1,
-        coverage_pybedtools,
-        coverage_genomicranges,
-    ]
-
-    functions_read_vcf = [
-        read_vcf_polars_bio,
-    ]
-
-    functions_e2 = [
-        e2e_overlap_polars_bio,
-        e2e_overlap_bioframe,
-        e2e_overlap_pyranges1,
-        e2e_overlap_genomicranges,
-        e2e_overlap_polars_bio_streaming,
-        e2e_nearest_polars_bio,
-        e2e_nearest_bioframe,
-        e2e_nearest_pyranges1,
-        e2e_nearest_genomicranges,
-        e2e_nearest_polars_bio_streaming,
-        e2e_coverage_polars_bio,
-        e2e_coverage_bioframe,
-        e2e_coverage_pyranges1,
-        e2e_coverage_polars_bio_streaming,
-        e2e_count_overlaps_polars_bio,
-        e2e_count_overlaps_bioframe,
-        e2e_count_overlaps_pyranges1,
-        e2e_count_overlaps_genomicranges,
-        e2e_count_overlaps_polars_bio_streaming,
-    ]
-
-    prepare_datatests(datasets, BECH_DATA_ROOT)
+    prepare_datatests(datasets, bench_data_root)
 
     run_benchmark(
         benchmarks,
         test_cases,
-        functions_overlap,
-        functions_nearest,
-        functions_count_overlaps,
-        functions_merge,
-        functions_cluster,
-        functions_complement,
-        functions_subtract,
-        functions_coverage,
-        functions_read_vcf,
-        functions_e2,
-        BECH_DATA_ROOT,
+        bench_data_root,
         output_dir,
         baseline,
         export_format,
+        default_polars_bio_output_type=default_polars_bio_output_type,
+        default_polars_bio_coordinate_system=default_polars_bio_coordinate_system,
+        default_polars_bio_consume_mode=default_polars_bio_consume_mode,
     )
     logger.info(emoji.emojize("Finished polars_bio_benchmark :check_mark_button:"))
 


### PR DESCRIPTION
## Summary
- build on the dataframe benchmark input work already on `feature/benchmark-dataframe-inputs`
- add a `pandas.pyarrow.DataFrame` `polars_bio` input variant that reads parquet with `engine="pyarrow"` and `dtype_backend="pyarrow"`
- add the new option to `conf/benchmark_dataframes.yaml` and document it in the README

## Validation
- `/Users/mwiewior/Library/Caches/pypoetry/virtualenvs/polars-bio-bench-AbPsZ0CB-py3.12/bin/python -m py_compile src/run-benchmarks.py`
- Arrow-backed pandas smoke test for `TestCaseInputs(...).polars_bio_inputs("pandas.pyarrow.DataFrame")`
- `/Users/mwiewior/Library/Caches/pypoetry/virtualenvs/polars-bio-bench-AbPsZ0CB-py3.12/bin/python src/run-benchmarks.py --help`
- `poetry run pre-commit run --files src/run-benchmarks.py conf/benchmark_dataframes.yaml README.md`
